### PR TITLE
Port is `0` on Mac for UDP when State is empty #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 yarn.lock
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn.lock
 
 .idea
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - '4'
+  - '6'
+  - '8'
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - '8'
   - '6'
   - '4'
+os:
+  - linux
+  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: node_js
 node_js:
-  - '8'
-  - '6'
   - '4'
 os:
-  - linux
   - osx
-
-after_success: npm run test:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '4'
+  - '4.8.7'
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
 os:
   - linux
   - osx
+
+after_success: npm run test:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - '4'
+  - 'stable'
 os:
+  - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
   - '4'
-  - '6'
-  - '8'
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '4.8.7'
+  - '4'
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
 os:
   - linux
   - osx
+
+after_success: npm run test:report

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,3 +14,5 @@ test_script:
 image:
   - Visual Studio 2017
   - Visual Studio 2015
+
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: '8'
+    - nodejs_version: 'stable'
     - nodejs_version: '6'
     - nodejs_version: '4'
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,21 @@ environment:
     - nodejs_version: "8"
 
 install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install --global npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 
+matrix:
+  fast_finish: true
+
+build: off
+
 test_script:
+  - node --version
+  - npm --version
   - npm test
 
 image:
   - Visual Studio 2017
   - Visual Studio 2015
-
-build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ install:
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 
-matrix:
-  fast_finish: true
-
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,20 @@
 environment:
   matrix:
-    # node.js
-    - nodejs_version: "4"
-    - nodejs_version: "6"
-    - nodejs_version: "8"
-
+    - nodejs_version: '8'
+    - nodejs_version: '6'
+    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install --global npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
-
+matrix:
+  fast_finish: true
 build: off
-
+shallow_clone: true
 test_script:
   - node --version
   - npm --version
   - npm test
-
-image:
-  - Visual Studio 2017
-  - Visual Studio 2015
+cache:
+  - '%APPDATA%\npm-cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,3 @@ test_script:
 image:
   - Visual Studio 2017
   - Visual Studio 2015
-  - Ubuntu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install --global npm@latest
+  - npm install --global npm@5.6.0
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+
+install:
+  - npm install
+
+test_script:
+  - npm test
+
+image:
+  - Visual Studio 2017
+  - Visual Studio 2015
+  - Ubuntu

--- a/index.js
+++ b/index.js
@@ -71,15 +71,13 @@ list.push(splitRowOnData(inserStatePlaceholder(row)));
 				}, [])
 		);
 
-const get = input => {
+module.exports = input => {
 	if (typeof input !== 'number') {
 		return Promise.reject(new TypeError(`Expected a number, got ${typeof input}`));
 	}
 
 	return getList().then(list => getPort(input, list));
 };
-
-module.exports = get;
 
 module.exports.all = input => {
 	if (!Array.isArray(input)) {

--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ const parsePid = input => {
 };
 
 const getPort = (input, list) => {
-	console.log({input});
-	console.log({list});
+	// Console.log({input});
+	// console.log({list});
 	const regex = new RegExp(`[.:]${input}$`);
 	const port = list.find(x => regex.test(x[cols[0]]));
 
@@ -91,8 +91,7 @@ module.exports.all = input => {
 	if (!Array.isArray(input)) {
 		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
 	}
-	console.log(input);
-	getList().then(console.log);
+
 	return getList()
 		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
 		.then(list => new Map(list));

--- a/index.js
+++ b/index.js
@@ -2,17 +2,30 @@
 
 const execa = require('execa');
 
+// :: n -> Boolean
 const isNumber = n => typeof n === 'number' && !Number.isNaN(n); // Typeof n === 'number' isn't good enough, you want to catch NaN, as well
+// :: String -> Boolean
 const isProtocol = str => /^\s*(?:tcp|udp)/i.test(str); // Don't capture if you don't have to, it's probably more efficient. It was (tcp|udp)
+// :: Regexp -> String -> [ String ]
 const splitOn = rx => str => str.trim().split(rx); // Re-use for two similar scenarios
+// :: String -> [ String ]
 const splitOnWs = splitOn(/\s+/);
+// :: String -> [ String ]
 const splitOnLf = splitOn(/\r?\n/);
 
-const zipToObject = keys => values => keys.reduce((obj, key, i) => { // I removed the `Object.assign()` since it's too slow to justify just to get a one-liner
+// Associates the Strings from one array to the Strings of another to create single object of key, value pairs
+//  :: [ String ] -> [ String ] -> Object
+const zipToObject = keys => values => keys.reduce((obj, key, i) => {
 	obj[key] = values[i];
 	return obj;
 }, {});
 
+/**
+ * Turns an ascii table-like output string into headers and rows.
+ *
+ * @param {string} str
+ * @return {{headers: [String], rows: [[String]]}}
+ */
 function stringToTable(str) {
 	str = str || '';
 	const rows = splitOnLf(str);
@@ -24,12 +37,25 @@ function stringToTable(str) {
 	};
 }
 
+/**
+ * Turns a table of headers and rows into an array of standard objects.
+ *
+ * @param {{headers: [String], rows: [[String]]}} table
+ * @return {[[Object]]}
+ */
 function tableToDict(table) {
 	const addAsValues = zipToObject(table.headers);
 
 	return table.rows.map(addAsValues);
 }
 
+/**
+ * Takes an ascii table-like output string,
+ * filters out non-tcp and non-udp related rows,
+ * and converts what's left into a list of arrays
+ * @param {string} [str='']
+ * @return {[String]}
+ */
 function stringToProtocolList(str) {
 	str = str || '';
 	return splitOnLf(str)
@@ -41,19 +67,23 @@ function stringToProtocolList(str) {
 			return result;
 		}, []);
 }
-
+// :: void -> Promise [Object] []
 const lsof = () =>
 		execa.stdout('lsof', ['-Pn', '-i'])
 			.then(stringToTable)
 			.then(tableToDict)
 			.catch(() => []); // When nothing is found, pass the empty array along to the user and let them decide how to handle the situation
-
+// :: void -> Promise [String]
 const win32 = () => execa.stdout('netstat', ['-ano']).then(stringToProtocolList);
 
 const os = process.platform;
 const cols = os === 'darwin' || os === 'linux' ? {port: 'name', pid: 'pid'} : {port: 1, pid: 4};
 const getList = os === 'win32' ? win32 : lsof;
-
+/**
+ * Extract the pid number from a matching string
+ * @param {string} input
+ * @returns {number|null}
+ */
 const parsePid = input => {
 	if (typeof input !== 'string') {
 		return null;
@@ -64,10 +94,16 @@ const parsePid = input => {
 	return match ? parseInt(match[1], 10) : null;
 };
 
+/**
+ * Find a pid from a given list that has a given port
+ * @param {string|number} input
+ * @param {[string]} list
+ * @returns {number|null} - returns the result of parsePid
+ */
 const getPort = (input, list) => {
 	const regex = new RegExp(`[.:]${input}$`);
 	const port = list.find(x => regex.test(x[cols.port]));
-	// Console.log(list);
+
 	if (!port) {
 		throw new Error(`Couldn't find a process with port \`${input}\``);
 	}
@@ -75,6 +111,11 @@ const getPort = (input, list) => {
 	return parsePid(port[cols.pid]);
 };
 
+/**
+ * Finds the pid of a process running on a given port
+ * @param {number} input
+ * @returns {number|null}
+ */
 module.exports = input => {
 	if (!isNumber(input)) {
 		return Promise.reject(new TypeError(`Expected a number, got ${typeof input}`));
@@ -83,6 +124,11 @@ module.exports = input => {
 	return getList().then(list => getPort(input, list));
 };
 
+/**
+ * Finds the pids of processes running on a list given port
+ * @param {[number]} input - a list of ports you want pids for
+ * @returns {Map}
+ */
 module.exports.all = input => {
 	if (!Array.isArray(input)) {
 		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
@@ -93,6 +139,10 @@ module.exports.all = input => {
 		.then(list => new Map(list));
 };
 
+/**
+ * Get a list of all of the pids and ports for currently running TCP and UDP processes
+ * @returns {ValueGenerator<Map<any, any>>|*|Promise<Map<any, any>>|PromiseLike<Map<any, any>>}
+ */
 module.exports.list = () => getList().then(list => {
 	const ret = new Map();
 

--- a/index.js
+++ b/index.js
@@ -105,8 +105,6 @@ module.exports.list = () => getList().then(list => {
 });
 
 console.log('Version: ' + process.version);
-
-
 //
 // module.exports.list = () =>
 // 	getList()

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-console.log('Version: ' + process.version);
 
 const execa = require('execa');
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ const getListFn = process.platform === 'darwin' ? macos : process.platform === '
 const cols = process.platform === 'darwin' ? [3, 8] : process.platform === 'linux' ? [4, 6] : [1, 4];
 
 const isProtocol = str => /^\s*(tcp|udp)/i.test(str);
+
+// There are situations where the state column is empty, this will ensure the column is not empty,
+// and therefore not lost when the row is turned to an array
 const insertStatePlaceholder = startIndex => string => (
 	string[startIndex] === ' ' ?
 			string.slice(0, startIndex) + 'STATE' + string.slice(startIndex) :
@@ -20,7 +23,7 @@ const insertStatePlaceholder = startIndex => string => (
 );
 
 const splitRowOnData = str => (
-	str.trim().split(/\s+/)
+	str.trim().split(/\s+/) // Leading white space would be included in the slit array, Trim ensures that there isn't any
 );
 
 const parsePid = input => {
@@ -62,12 +65,12 @@ const getList = () =>
 				list
 			};
 		})
-		.then(({insertStatePlaceholder, list}) =>
-			list
+		.then(state =>
+			state.list
 				.split('\n')
 				.reduce((list, row) => {
 					if (isProtocol(row)) {
-list.push(splitRowOnData(insertStatePlaceholder(row)));
+						list.push(splitRowOnData(state.insertStatePlaceholder(row)));
 					}
 
 					return list;
@@ -113,9 +116,7 @@ if (process.env.NODE_ENV === 'test') {
 		insertStatePlaceholder,
 		splitRowOnData,
 		parsePid,
-		getPort,
-		findStateIndex,
-		getList
+		findStateIndex
 	};
 }
 
@@ -131,4 +132,3 @@ if (process.env.NODE_ENV === 'test') {
 // 				return acc;
 // 			}, new Map());
 // 		});
-

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const splitStringOnData = str => (
 const zipToObject = keys => values =>
     keys.reduce((obj, key, i) => Object.assign({}, obj, {[key]: values[i]}), {});
 
-function stringToTable(str = '') {
+function stringToTable(str) {
+	str = str || '';
 	const rows = str.split('\n');
 	const headers = splitStringOnData(rows.shift()).map(str => str.toLowerCase());
 
@@ -21,13 +22,14 @@ function stringToTable(str = '') {
 	};
 }
 
-function tableToDict({headers, rows}) {
-	const addAsValues = zipToObject(headers);
+function tableToDict(table) {
+	const addAsValues = zipToObject(table.headers);
 
-	return rows.map(addAsValues);
+	return table.rows.map(addAsValues);
 }
 
-function stringToProtocolList(str = '') {
+function stringToProtocolList(str) {
+	str = str || '';
 	return str
 		.split('\n')
 		.reduce((result, x) => {

--- a/index.js
+++ b/index.js
@@ -103,6 +103,10 @@ module.exports.list = () => getList().then(list => {
 
 	return ret;
 });
+
+console.log('Version: ' + process.version);
+
+
 //
 // module.exports.list = () =>
 // 	getList()

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ const parsePid = input => {
 };
 
 const getPort = (input, list) => {
+	console.log({input});
+	console.log({list});
 	const regex = new RegExp(`[.:]${input}$`);
 	const port = list.find(x => regex.test(x[cols[0]]));
 

--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ module.exports.all = input => {
 	}
 
 	return getList()
+		.then(list => {
+			console.log(list);
+			return list;
+		})
 		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
 		.then(list => new Map(list));
 };

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports.all = input => {
 	if (!Array.isArray(input)) {
 		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
 	}
-
+	console.log(input);
 	return getList()
 		.then(list => {
 			console.log(list);

--- a/index.js
+++ b/index.js
@@ -87,21 +87,7 @@ module.exports = input => {
 	return getList().then(list => getPort(input, list));
 };
 
-module.exports.all = input => {
-	if (!Array.isArray(input)) {
-		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
-	}
-	console.log(input);
-	return getList()
-		.then(list => {
-			console.log(list);
-			return list;
-		})
-		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
-		.then(list => new Map(list));
-};
-
-module.exports.list = () => getList().then(list => {
+const list = () => getList().then(list => {
 	const ret = new Map();
 
 	for (const x of list) {
@@ -114,6 +100,24 @@ module.exports.list = () => getList().then(list => {
 
 	return ret;
 });
+
+module.exports.all = input => {
+	if (!Array.isArray(input)) {
+		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
+	}
+	console.log(input);
+	return list()
+		.then(console.log)
+		.then(getList)
+		// .then(list => {
+		// 	console.log(list);
+		// 	return list;
+		// })
+		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
+		.then(list => new Map(list));
+};
+
+module.exports.list = list;
 
 if (process.env.NODE_ENV === 'test') {
 	module.exports.util = {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 'use strict';
+console.log('Version: ' + process.version);
+
 const execa = require('execa');
 
 const macos = () => execa.stdout('netstat', ['-anv', '-p', 'tcp'])
@@ -104,7 +106,6 @@ module.exports.list = () => getList().then(list => {
 	return ret;
 });
 
-console.log('Version: ' + process.version);
 //
 // module.exports.list = () =>
 // 	getList()

--- a/index.js
+++ b/index.js
@@ -2,29 +2,41 @@
 
 const execa = require('execa');
 
-const macos = () => execa.stdout('netstat', ['-anv', '-p', 'tcp'])
-	.then(data => Promise.all([data, execa.stdout('netstat', ['-anv', '-p', 'udp'])]))
-	.then(data => data.join('\n'));
-
-const linux = () => execa.stdout('ss', ['-tunlp']);
-const win32 = () => execa.stdout('netstat', ['-ano']);
-
-const getListFn = process.platform === 'darwin' ? macos : process.platform === 'linux' ? linux : win32;
-const cols = process.platform === 'darwin' ? [3, 8] : process.platform === 'linux' ? [4, 6] : [1, 4];
-
 const isProtocol = str => /^\s*(tcp|udp)/i.test(str);
 
-// There are situations where the state column is empty, this will ensure the column is not empty,
-// and therefore not lost when the row is turned to an array
-const insertStatePlaceholder = startIndex => string => (
-	string[startIndex] === ' ' ?
-			string.slice(0, startIndex) + 'STATE' + string.slice(startIndex) :
-		string
-);
-
-const splitRowOnData = str => (
+const splitStringOnData = str => (
 	str.trim().split(/\s+/) // Leading white space would be included in the slit array, Trim ensures that there isn't any
 );
+
+const zipToObject = keys => values =>
+	keys.reduce((obj, key, i) => Object.assign({}, obj, {[key]: values[i]}), {});
+
+const toLowerCase = str => str.toLowerCase();
+
+const lsof = () => execa.stdout('lsof', ['-P', '-i'])
+	.then(results => {
+		const rows = results.split('\n');
+		const headers = rows.shift();
+
+		const addAsValues = zipToObject(splitStringOnData(headers).map(toLowerCase));
+		return rows
+			.map(row => addAsValues(splitStringOnData(row)));
+	});
+
+const win32 = () => execa.stdout('netstat', ['-ano'])
+	.then(list => list
+		.split('\n')
+		.reduce((result, x) => {
+			if (isProtocol(x)) {
+				result.push(x.match(/\S+/g) || []);
+			}
+
+			return result;
+		}, [])
+	);
+
+const getList = process.platform === 'darwin' ? lsof : process.platform === 'linux' ? lsof : win32;
+const cols = process.platform === 'darwin' ? {port: 'name', pid: 'pid'} : process.platform === 'linux' ? {port: 'name', pid: 'pid'} : {port: 1, pid: 4};
 
 const parsePid = input => {
 	if (typeof input !== 'string') {
@@ -36,48 +48,15 @@ const parsePid = input => {
 };
 
 const getPort = (input, list) => {
-	// Console.log({input});
-	// console.log({list});
 	const regex = new RegExp(`[.:]${input}$`);
-	const port = list.find(x => regex.test(x[cols[0]]));
-
+	const port = list.find(x => regex.test(x[cols.port]));
+	// Console.log(list);
 	if (!port) {
 		throw new Error(`Couldn't find a process with port \`${input}\``);
 	}
 
-	return parsePid(port[cols[1]]);
+	return parsePid(port[cols.pid]);
 };
-
-function findStateIndex(listTable) {
-	if (typeof listTable !== 'string') {
-		return null;
-	}
-
-	const header = listTable.match(/\n?(.*(state).*)\n/i); // The (.*, .*) are so this will capture the whole line
-	return header ? header[1].search(/state/i) : null;
-}
-
-const getList = () =>
-	getListFn()
-		.then(list => {
-			const stateIndex = findStateIndex(list);
-
-			return {
-				insertStatePlaceholder: insertStatePlaceholder(stateIndex),
-				list
-			};
-		})
-		.then(state =>
-			state.list
-				.split('\n')
-				.reduce((list, row) => {
-					if (isProtocol(row)) {
-						list.push(splitRowOnData(state.insertStatePlaceholder(row)));
-					}
-
-					return list;
-				}, [])
-		);
 
 module.exports = input => {
 	if (typeof input !== 'number') {
@@ -87,58 +66,34 @@ module.exports = input => {
 	return getList().then(list => getPort(input, list));
 };
 
-const list = () => getList().then(list => {
+module.exports.all = input => {
+	if (!Array.isArray(input)) {
+		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
+	}
+
+	return getList()
+		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
+		.then(list => new Map(list));
+};
+
+module.exports.list = () => getList().then(list => {
 	const ret = new Map();
 
 	for (const x of list) {
-		const match = x[cols[0]].match(/[^]*[.:](\d+)$/);
+		const match = x[cols.port].match(/[^]*[.:](\d+)$/);
 
 		if (match) {
-			ret.set(parseInt(match[1], 10), parsePid(x[cols[1]]));
+			ret.set(parseInt(match[1], 10), parsePid(x[cols.pid]));
 		}
 	}
 
 	return ret;
 });
 
-module.exports.all = input => {
-	if (!Array.isArray(input)) {
-		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
-	}
-	console.log(input);
-	return list()
-		.then(console.log)
-		.then(getList)
-		// .then(list => {
-		// 	console.log(list);
-		// 	return list;
-		// })
-		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
-		.then(list => new Map(list));
-};
-
-module.exports.list = list;
-
 if (process.env.NODE_ENV === 'test') {
 	module.exports.util = {
-		getListFn,
 		isProtocol,
-		insertStatePlaceholder,
-		splitRowOnData,
-		parsePid,
-		findStateIndex
+		splitStringOnData,
+		parsePid
 	};
 }
-
-//
-// module.exports.list = () =>
-// 	getList()
-// 		.then(list => {
-// 			return list.reduce((acc, x) => {
-// 				const match = x[cols[0]].match(/[^]*[.:](\d+)$/);
-// 				if (match) {
-// 					acc.set(parseInt(match[1], 10), parsePid(x[cols[1]]));
-// 				}
-// 				return acc;
-// 			}, new Map());
-// 		});

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ const lsof = () => execa.stdout('lsof', ['-P', '-i'])
 		const addAsValues = zipToObject(splitStringOnData(headers).map(toLowerCase));
 		return rows
 			.map(row => addAsValues(splitStringOnData(row)));
-	});
+	})
+	.catch(() => []);
 
 const win32 = () => execa.stdout('netstat', ['-ano'])
 	.then(list => list

--- a/index.js
+++ b/index.js
@@ -89,7 +89,8 @@ module.exports.all = input => {
 	if (!Array.isArray(input)) {
 		return Promise.reject(new TypeError(`Expected an array, got ${typeof input}`));
 	}
-
+	console.log(input);
+	getList().then(console.log);
 	return getList()
 		.then(list => Promise.all(input.map(x => [x, getPort(x, list)])))
 		.then(list => new Map(list));

--- a/index.js
+++ b/index.js
@@ -131,3 +131,4 @@ if (process.env.NODE_ENV === 'test') {
 // 				return acc;
 // 			}, new Map());
 // 		});
+

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const splitStringOnData = str => (
 
 const zipToObject = keys => values =>
 	keys.reduce((obj, key, i) => Object.assign({}, obj, {[key]: values[i]}), {});
-
+// String -> string
 const toLowerCase = str => str.toLowerCase();
 
 function stringToTable(str = '') {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
+	  	"test:coverage": "nyc npm test",
+	  	"test:watch": "npm test -- --watch"
 	},
 	"files": [
 		"index.js"
@@ -29,7 +31,9 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"cross-env": "^5.1.4",
 		"get-port": "^3.2.0",
+		"nyc": "^11.7.1",
 		"pre-commit": "^1.2.2",
 		"xo": "*"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pid-from-port",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Get PID from a port",
 	"license": "MIT",
 	"repository": "kevva/pid-from-port",
@@ -16,8 +16,8 @@
 		"run-test": "cross-env NODE_ENV=test xo --fix && xo && ava",
 		"test:4": "npx --package=node-bin@4 -- npm test",
 		"test:6": "npx --package=node-bin@6 -- npm test",
-		"test:8": "npx --package=node-bin@8 -- npm test",
-		"test:history": "npm run test:4 && npm run test:6 && npm run test: 8",
+		"test:stable": "npx --package=node-bin@stable -- npm test",
+		"test:history": "npm run test:4 && npm run test:6 && npm run test:stable",
 		"test": "nyc npm run run-test",
 		"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
 	},
 	"scripts": {
 		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
+		"test:4": "npx --package=node-bin@4 -- npm test",
+		"test:6": "npx --package=node-bin@6 -- npm test",
+		"test:8": "npx --package=node-bin@8 -- npm test",
+	  	"test:history": "npm run test:4 && npm run test:6 && npm run test: 8",
 		"test:coverage": "nyc npm test",
 	  	"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"

--- a/package.json
+++ b/package.json
@@ -9,13 +9,6 @@
 		"email": "kevinmartensson@gmail.com",
 		"url": "github.com/kevva"
 	},
-	"contributors": [
-		{
-			"name": "Danny Michaelis",
-			"email": "dmichaelis0@gmail.com",
-			"url": "github.com/easilyBaffled"
-		}
-	],
 	"engines": {
 		"node": ">=4"
 	},
@@ -39,18 +32,17 @@
 		"port"
 	],
 	"dependencies": {
-		"coveralls": "^3.0.0",
-		"execa": "^0.9.0",
-		"type-detect": "^4.0.8"
+		"execa": "^0.9.0"
 	},
 	"devDependencies": {
-		"ava": "^1.0.0-beta.4",
-		"ava-check": "^1.0.0-rc.0",
-		"cross-env": "^5.1.4",
+		"ava": "*",
+	  	"coveralls": "^3.0.0",
+	  	"cross-env": "^5.1.4",
 		"get-port": "^3.2.0",
 		"nyc": "^11.7.1",
 		"pre-commit": "^1.2.2",
 		"testcheck": "^1.0.0-rc.2",
+	  	"type-detect": "^4.0.8",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
 	},
 	"scripts": {
 		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
-	  	"test:coverage": "nyc npm test",
-	  	"test:watch": "npm test -- --watch"
+		"test:coverage": "nyc npm test",
+	  	"test:report": "nyc report --reporter=text-lcov | coveralls",
+		"test:watch": "npm test -- --watch"
 	},
 	"files": [
 		"index.js"
@@ -27,6 +28,7 @@
 		"port"
 	],
 	"dependencies": {
+		"coveralls": "^3.0.0",
 		"execa": "^0.9.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
 		"email": "kevinmartensson@gmail.com",
 		"url": "github.com/kevva"
 	},
+	"contributors": [
+		{
+		  "name": "Danny Michaelis",
+		  "email": "dmichaelis0@gmail.com",
+		  "url": "github.com/easilyBaffled"
+		}
+	],
 	"engines": {
 		"node": ">=4"
 	},

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
 		"pre-commit": "^1.2.2",
 		"testcheck": "^1.0.0-rc.2",
 	  	"type-detect": "^4.0.8",
-		"xo": "*"
+		"xo": "0.20.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
+		"test": "xo && ava",
 		"test:coverage": "nyc npm test",
 	  	"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "xo && ava",
+		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
 		"test:coverage": "nyc npm test",
 	  	"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "cross-env NODE_ENV=test xo --fix && xo && ava",
+		"run-test": "cross-env NODE_ENV=test xo --fix && xo && ava",
 		"test:4": "npx --package=node-bin@4 -- npm test",
 		"test:6": "npx --package=node-bin@6 -- npm test",
 		"test:8": "npx --package=node-bin@8 -- npm test",
 		"test:history": "npm run test:4 && npm run test:6 && npm run test: 8",
-		"test:coverage": "nyc npm test",
+		"test": "nyc npm run run-test",
 		"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"
 	},

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 	},
 	"contributors": [
 		{
-		  "name": "Danny Michaelis",
-		  "email": "dmichaelis0@gmail.com",
-		  "url": "github.com/easilyBaffled"
+			"name": "Danny Michaelis",
+			"email": "dmichaelis0@gmail.com",
+			"url": "github.com/easilyBaffled"
 		}
 	],
 	"engines": {
@@ -24,9 +24,9 @@
 		"test:4": "npx --package=node-bin@4 -- npm test",
 		"test:6": "npx --package=node-bin@6 -- npm test",
 		"test:8": "npx --package=node-bin@8 -- npm test",
-	  	"test:history": "npm run test:4 && npm run test:6 && npm run test: 8",
+		"test:history": "npm run test:4 && npm run test:6 && npm run test: 8",
 		"test:coverage": "nyc npm test",
-	  	"test:report": "nyc report --reporter=text-lcov | coveralls",
+		"test:report": "nyc report --reporter=text-lcov | coveralls",
 		"test:watch": "npm test -- --watch"
 	},
 	"files": [
@@ -40,14 +40,17 @@
 	],
 	"dependencies": {
 		"coveralls": "^3.0.0",
-		"execa": "^0.9.0"
+		"execa": "^0.9.0",
+		"type-detect": "^4.0.8"
 	},
 	"devDependencies": {
-		"ava": "*",
+		"ava": "^1.0.0-beta.4",
+		"ava-check": "^1.0.0-rc.0",
 		"cross-env": "^5.1.4",
 		"get-port": "^3.2.0",
 		"nyc": "^11.7.1",
 		"pre-commit": "^1.2.2",
+		"testcheck": "^1.0.0-rc.2",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
 		"port"
 	],
 	"dependencies": {
-		"execa": "^0.9.0"
+		"execa": "^0.10.0"
 	},
 	"devDependencies": {
 		"ava": "*",
 	  	"coveralls": "^3.0.0",
 	  	"cross-env": "^5.1.4",
-		"get-port": "^3.2.0",
-		"nyc": "^11.7.1",
+		"get-port": "^4.0.0",
+		"nyc": "^12.0.2",
 		"pre-commit": "^1.2.2",
 		"testcheck": "^1.0.0-rc.2",
 	  	"type-detect": "^4.0.8",
-		"xo": "0.20.0"
+		"xo": "0.21.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"devDependencies": {
 		"ava": "*",
 		"get-port": "^3.2.0",
+		"pre-commit": "^1.2.2",
 		"xo": "*"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# pid-from-port [![Build Status](https://travis-ci.org/kevva/pid-from-port.svg?branch=master)](https://travis-ci.org/kevva/pid-from-port)
+# pid-from-port [![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port)
 
 > Get PID from a port
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# pid-from-port [![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port)
+# pid-from-port [![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port) [![Build status](https://ci.appveyor.com/api/projects/status/8mh3i140nq32c7vw/branch/master?svg=true)](https://ci.appveyor.com/project/easilyBaffled/pid-from-port/branch/master)
 
 > Get PID from a port
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/pid-from-port.svg)](https://badge.fury.io/js/pid-from-port)
 [![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port) 
 [![Build status](https://ci.appveyor.com/api/projects/status/8mh3i140nq32c7vw/branch/master?svg=true)](https://ci.appveyor.com/project/easilyBaffled/pid-from-port/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/easilyBaffled/pid-from-port/badge.svg?branch=master)](https://coveralls.io/github/easilyBaffled/pid-from-port?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/easilyBaffled/pid-from-port/badge.svg?branch=master)](https://coveralls.io/github/easilyBaffled/pid-from-port?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/easilyBaffled/pid-from-port.svg)](https://greenkeeper.io/)
 > Get PID from a port
 
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
-# pid-from-port [![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port) [![Build status](https://ci.appveyor.com/api/projects/status/8mh3i140nq32c7vw/branch/master?svg=true)](https://ci.appveyor.com/project/easilyBaffled/pid-from-port/branch/master)
-
+# pid-from-port 
+[![npm version](https://badge.fury.io/js/pid-from-port.svg)](https://badge.fury.io/js/pid-from-port)
+[![Build Status](https://travis-ci.org/easilyBaffled/pid-from-port.svg?branch=master)](https://travis-ci.org/easilyBaffled/pid-from-port) 
+[![Build status](https://ci.appveyor.com/api/projects/status/8mh3i140nq32c7vw/branch/master?svg=true)](https://ci.appveyor.com/project/easilyBaffled/pid-from-port/branch/master)
+[![Coverage Status](https://coveralls.io/repos/github/easilyBaffled/pid-from-port/badge.svg?branch=master)](https://coveralls.io/github/easilyBaffled/pid-from-port?branch=master)
 > Get PID from a port
 
 

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/(^\s*(udp|tcp).*\s*$)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+'use strict';
 import http from 'http';
 import {serial as test} from 'ava';
 import getPort from 'get-port';
@@ -52,7 +53,7 @@ test('list', async t => {
 	t.true(list instanceof Map);
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
-
+/*
 // PidFromPort.util
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
@@ -109,3 +110,4 @@ test('findStateIndex', t => {
 	t.is(findStateIndex('  (State)\n'), 3);
 	t.is(findStateIndex('  (STATE) \n'), 3);
 });
+*/

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/\n?\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -1,18 +1,28 @@
 'use strict';
-// Import http from 'http';
+import http from 'http';
 import {serial as test} from 'ava';
-// Import getPort from 'get-port';
+import getPort from 'get-port';
 import m from '.';
 
-// Const pidFromPort = m;
-//
-// const startNewServer = port => {
-// 	const server = http.createServer((req, res) => {
-// 		res.end();
-// 	});
-// 	server.listen(port);
-// 	return server;
-// };
+const pidFromPort = m;
+
+const startNewServer = port => {
+	const server = http.createServer((req, res) => {
+		res.end();
+	});
+	server.listen(port);
+	return server;
+};
+
+// (async () => {
+// 	try {
+// 		const list = await m.list();
+// 		m.all(Array.from(list.keys())).then( console.log )
+// 	} catch (e) {
+// 		// Deal with the fact the chain failed
+// 		console.log(e);
+// 	}
+// })();
 
 test('list', async t => {
 	const list = await m.list();
@@ -20,7 +30,7 @@ test('list', async t => {
 	console.log({list});
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
-/*
+
 // PidFromPort
 test('success', async t => {
 	const port = await getPort();
@@ -118,4 +128,3 @@ test('findStateIndex', t => {
 	t.is(findStateIndex('  (State)\n'), 3);
 	t.is(findStateIndex('  (STATE) \n'), 3);
 });
-*/

--- a/test.js
+++ b/test.js
@@ -57,6 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
+	console.log(table);
 	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 

--- a/test.js
+++ b/test.js
@@ -51,6 +51,7 @@ test('all', async t => {
 test('list', async t => {
 	const list = await m.list();
 	t.true(list instanceof Map);
+	console.log({list});
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
 

--- a/test.js
+++ b/test.js
@@ -3,11 +3,11 @@ import http from 'http';
 import {serial as test} from 'ava';
 import getPort from 'get-port';
 import type from 'type-detect';
-import execa from 'execa';
+
 import m from '.';
 
 const pidFromPort = m;
-
+const values = obj => Object.keys(obj).map(k => obj[k]);
 const startNewServer = port => {
 	const server = http.createServer((req, res) => {
 		res.end();
@@ -96,7 +96,7 @@ test('zipToObject', t => {
 			t.deepEqual(zipToObject([])(notArray), {});
 		});
 	const obj = {a: 1, b: 2, c: 3};
-	t.deepEqual(zipToObject(Object.keys(obj))(Object.values(obj)), obj);
+	t.deepEqual(zipToObject(Object.keys(obj))(values(obj)), obj);
 });
 
 const {stringToTable} = m.util;
@@ -167,6 +167,3 @@ test('stringToProtocolList', t => {
 		]
 	);
 });
-
-execa.stdout('lsof', ['-Pn', '-i'])
-	.then(console.log);

--- a/test.js
+++ b/test.js
@@ -1,18 +1,18 @@
 'use strict';
-import http from 'http';
+// Import http from 'http';
 import {serial as test} from 'ava';
-import getPort from 'get-port';
+// Import getPort from 'get-port';
 import m from '.';
 
-const pidFromPort = m;
-
-const startNewServer = port => {
-	const server = http.createServer((req, res) => {
-		res.end();
-	});
-	server.listen(port);
-	return server;
-};
+// Const pidFromPort = m;
+//
+// const startNewServer = port => {
+// 	const server = http.createServer((req, res) => {
+// 		res.end();
+// 	});
+// 	server.listen(port);
+// 	return server;
+// };
 
 // (async () => {
 // 	try {
@@ -24,6 +24,15 @@ const startNewServer = port => {
 // 	}
 // })();
 
+// PidFromPort.list
+test('list', async t => {
+	const list = await m.list();
+	t.true(list instanceof Map);
+	// Console.log({list});
+	await t.notThrows(m.all(Array.from(list.keys())));
+});
+
+/*
 // PidFromPort
 test('success', async t => {
 	const port = await getPort();
@@ -55,14 +64,6 @@ test('all', async t => {
 
 	s1.close();
 	s2.close();
-});
-
-// PidFromPort.list
-test('list', async t => {
-	const list = await m.list();
-	t.true(list instanceof Map);
-	console.log({list});
-	await t.notThrows(m.all(Array.from(list.keys())));
 });
 
 // PidFromPort.util
@@ -121,3 +122,4 @@ test('findStateIndex', t => {
 	t.is(findStateIndex('  (State)\n'), 3);
 	t.is(findStateIndex('  (STATE) \n'), 3);
 });
+*/

--- a/test.js
+++ b/test.js
@@ -2,8 +2,8 @@
 // Import http from 'http';
 import {serial as test} from 'ava';
 // Import getPort from 'get-port';
+import execa from 'execa';
 import m from '.';
-
 // Const pidFromPort = m;
 //
 // const startNewServer = port => {
@@ -26,11 +26,16 @@ import m from '.';
 
 // PidFromPort.list
 test('list', async t => {
+	const names = await execa.stdout('lsof');
+	console.log({names});
 	const list = await m.list();
 	t.true(list instanceof Map);
 	const altList = await m.list();
 	console.log({list});
 	console.log({altList});
+
+	const names2 = await execa.stdout('lsof');
+	console.log({names2});
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ const startNewServer = port => {
 	return server;
 };
 
+// PidFromPort
 test('success', async t => {
 	const port = await getPort();
 	const server = startNewServer(port);
@@ -26,9 +27,10 @@ test('fail', async t => {
 });
 
 test('accepts a number', async t => {
+	await t.throws(m('3000'), 'Expected a number, got string');
 	await t.throws(m('foo'), 'Expected a number, got string');
 });
-
+// PidFromPort.all
 test('all', async t => {
 	const [p1, p2] = await Promise.all([getPort(), getPort()]);
 	const [s1, s2] = [startNewServer(p1), startNewServer(p2)];
@@ -44,8 +46,66 @@ test('all', async t => {
 	s2.close();
 });
 
+// PidFromPort.list
 test('list', async t => {
 	const list = await m.list();
 	t.true(list instanceof Map);
 	await t.notThrows(m.all(Array.from(list.keys())));
+});
+
+// PidFromPort.util
+test('getListFn', async t => {
+	const table = await m.util.getListFn();
+	t.true(typeof table === 'string');
+	t.true(/(\D+\n){2}(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {2} Header rows and rows that start with udp or tcp
+});
+
+test('isProtocol', t => {
+	const {isProtocol} = m.util;
+	t.true(typeof isProtocol('fail') === 'boolean');
+	t.true(['fail', 0, [], -1, null, ' '].every(str => !isProtocol(str)));
+	t.true(['udp', 'tcp', 'UDP', 'TCP', '   udp', '  udp46'].every(isProtocol));
+});
+
+test('insertStatePlaceholder', t => {
+	const {insertStatePlaceholder} = m.util;
+	t.is(typeof insertStatePlaceholder(), 'function');
+	t.is(typeof insertStatePlaceholder()(''), 'string');
+	t.is(insertStatePlaceholder(0)(' starts with STATE'), 'STATE starts with STATE');
+	t.is(insertStatePlaceholder(12)('will insert  <- here'), 'will insert STATE <- here');
+	t.is(insertStatePlaceholder(0)('is unchanged'), 'is unchanged');
+});
+
+test('splitRowOnData', t => {
+	const {splitRowOnData} = m.util;
+	t.true(Array.isArray(splitRowOnData('')));
+	t.throws(splitRowOnData, 'Cannot read property \'trim\' of undefined');
+	t.is(splitRowOnData('abc').length, 1);
+	t.is(splitRowOnData(' abc').length, 1);
+	t.is(splitRowOnData(' a b c ').length, 3);
+	t.is(splitRowOnData(' a    c ').length, 2);
+});
+
+test('parsePid', t => {
+	const {parsePid} = m.util;
+	t.is(parsePid(), null);
+	t.is(parsePid(1234), null);
+	t.is(parsePid('bad string'), null);
+
+	t.true(['1234', '",1234', '   ",1234', '",pid=1234'].every(pid => parsePid(pid) === 1234));
+});
+
+test('findStateIndex', t => {
+	const {findStateIndex} = m.util;
+	t.is(findStateIndex(), null);
+	t.is(findStateIndex(1234), null);
+	t.is(findStateIndex('bad string'), null);
+
+	t.is(findStateIndex('\n anything state anything\n'), 10);
+	t.is(findStateIndex(' anything State anything\n'), 10);
+	t.is(findStateIndex(`
+	    state
+	    `), 5);
+	t.is(findStateIndex('  (State)\n'), 3);
+	t.is(findStateIndex('  (STATE) \n'), 3);
 });

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/(\D+\n){1,2}(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	console.log(table);
+	console.log('label', table);
 	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 

--- a/test.js
+++ b/test.js
@@ -28,7 +28,9 @@ import m from '.';
 test('list', async t => {
 	const list = await m.list();
 	t.true(list instanceof Map);
-	// Console.log({list});
+	const altList = await m.list();
+	console.log({list});
+	console.log({altList});
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
 

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table.trim())); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -3,14 +3,20 @@ import {serial as test} from 'ava';
 import getPort from 'get-port';
 import m from '.';
 
-const srv = () => http.createServer((req, res) => {
-	res.end();
-});
+const pidFromPort = m;
+
+const startNewServer = port => {
+	const server = http.createServer((req, res) => {
+		res.end();
+	});
+	server.listen(port);
+	return server;
+};
 
 test('success', async t => {
 	const port = await getPort();
-	const server = srv().listen(port);
-	t.truthy(await m(port));
+	const server = startNewServer(port);
+	t.truthy(await pidFromPort(port));
 	server.close();
 });
 
@@ -25,7 +31,7 @@ test('accepts a number', async t => {
 
 test('all', async t => {
 	const [p1, p2] = await Promise.all([getPort(), getPort()]);
-	const [s1, s2] = [srv().listen(p1), srv().listen(p2)];
+	const [s1, s2] = [startNewServer(p1), startNewServer(p2)];
 	const ports = await m.all([p1, p2]);
 
 	t.true(ports instanceof Map);

--- a/test.js
+++ b/test.js
@@ -1,19 +1,26 @@
 'use strict';
-import http from 'http';
+// Import http from 'http';
 import {serial as test} from 'ava';
-import getPort from 'get-port';
+// Import getPort from 'get-port';
 import m from '.';
 
-const pidFromPort = m;
+// Const pidFromPort = m;
+//
+// const startNewServer = port => {
+// 	const server = http.createServer((req, res) => {
+// 		res.end();
+// 	});
+// 	server.listen(port);
+// 	return server;
+// };
 
-const startNewServer = port => {
-	const server = http.createServer((req, res) => {
-		res.end();
-	});
-	server.listen(port);
-	return server;
-};
-
+test('list', async t => {
+	const list = await m.list();
+	t.true(list instanceof Map);
+	console.log({list});
+	await t.notThrows(m.all(Array.from(list.keys())));
+});
+/*
 // PidFromPort
 test('success', async t => {
 	const port = await getPort();
@@ -111,4 +118,4 @@ test('findStateIndex', t => {
 	t.is(findStateIndex('  (State)\n'), 3);
 	t.is(findStateIndex('  (STATE) \n'), 3);
 });
-
+*/

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/(\D+\n){2}(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {2} Header rows and rows that start with udp or tcp
+	t.true(/(\D+\n){1,2}(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ test('list', async t => {
 	t.true(list instanceof Map);
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
-/*
+
 // PidFromPort.util
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
@@ -110,4 +110,4 @@ test('findStateIndex', t => {
 	t.is(findStateIndex('  (State)\n'), 3);
 	t.is(findStateIndex('  (STATE) \n'), 3);
 });
-*/
+

--- a/test.js
+++ b/test.js
@@ -57,8 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	console.log('label', table);
-	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/\n?\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -24,13 +24,6 @@ const startNewServer = port => {
 // 	}
 // })();
 
-test('list', async t => {
-	const list = await m.list();
-	t.true(list instanceof Map);
-	console.log({list});
-	await t.notThrows(m.all(Array.from(list.keys())));
-});
-
 // PidFromPort
 test('success', async t => {
 	const port = await getPort();
@@ -65,11 +58,23 @@ test('all', async t => {
 });
 
 // PidFromPort.list
+// test('list', async t => {
+// 	const list = await m.list();
+// 	t.true(list instanceof Map);
+// 	console.log({list});
+// 	await t.notThrows(m.all(Array.from(list.keys())));
+// });
+
 test('list', async t => {
 	const list = await m.list();
 	t.true(list instanceof Map);
-	console.log({list});
-	await t.notThrows(m.all(Array.from(list.keys())));
+	// Console.log({list});
+	// await t.notThrows(m.all(Array.from(list.keys())));
+	await t.notThrows(m
+		.list()
+		.then(list => Array.from(list.keys()))
+		.then(m.all)
+	);
 });
 
 // PidFromPort.util

--- a/test.js
+++ b/test.js
@@ -1,39 +1,19 @@
 'use strict';
-// Import http from 'http';
+import http from 'http';
 import {serial as test} from 'ava';
-// Import getPort from 'get-port';
+import getPort from 'get-port';
 import m from '.';
-// Const pidFromPort = m;
-//
-// const startNewServer = port => {
-// 	const server = http.createServer((req, res) => {
-// 		res.end();
-// 	});
-// 	server.listen(port);
-// 	return server;
-// };
 
-// (async () => {
-// 	try {
-// 		const list = await m.list();
-// 		m.all(Array.from(list.keys())).then( console.log )
-// 	} catch (e) {
-// 		// Deal with the fact the chain failed
-// 		console.log(e);
-// 	}
-// })();
+const pidFromPort = m;
 
-// PidFromPort.list
-test('list', async t => {
-	const list = await m.list();
-	t.true(list instanceof Map);
-	const altList = await m.list();
-	console.log({list});
-	console.log({altList});
-	await t.notThrows(m.all(Array.from(list.keys())));
-});
+const startNewServer = port => {
+	const server = http.createServer((req, res) => {
+		res.end();
+	});
+	server.listen(port);
+	return server;
+};
 
-/*
 // PidFromPort
 test('success', async t => {
 	const port = await getPort();
@@ -67,13 +47,14 @@ test('all', async t => {
 	s2.close();
 });
 
-// PidFromPort.util
-test('getListFn', async t => {
-	const table = await m.util.getListFn();
-	t.true(typeof table === 'string');
-	t.true(/(^\s*(udp|tcp).*\s*$)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+// PidFromPort.list
+test('list', async t => {
+	const list = await m.list();
+	t.true(list instanceof Map);
+	await t.notThrows(m.all(Array.from(list.keys())));
 });
 
+// PidFromPort.util
 test('isProtocol', t => {
 	const {isProtocol} = m.util;
 	t.true(typeof isProtocol('fail') === 'boolean');
@@ -81,23 +62,14 @@ test('isProtocol', t => {
 	t.true(['udp', 'tcp', 'UDP', 'TCP', '   udp', '  udp46'].every(isProtocol));
 });
 
-test('insertStatePlaceholder', t => {
-	const {insertStatePlaceholder} = m.util;
-	t.is(typeof insertStatePlaceholder(), 'function');
-	t.is(typeof insertStatePlaceholder()(''), 'string');
-	t.is(insertStatePlaceholder(0)(' starts with STATE'), 'STATE starts with STATE');
-	t.is(insertStatePlaceholder(12)('will insert  <- here'), 'will insert STATE <- here');
-	t.is(insertStatePlaceholder(0)('is unchanged'), 'is unchanged');
-});
-
-test('splitRowOnData', t => {
-	const {splitRowOnData} = m.util;
-	t.true(Array.isArray(splitRowOnData('')));
-	t.throws(splitRowOnData, 'Cannot read property \'trim\' of undefined');
-	t.is(splitRowOnData('abc').length, 1);
-	t.is(splitRowOnData(' abc').length, 1);
-	t.is(splitRowOnData(' a b c ').length, 3);
-	t.is(splitRowOnData(' a    c ').length, 2);
+test('splitStringOnData', t => {
+	const {splitStringOnData} = m.util;
+	t.true(Array.isArray(splitStringOnData('')));
+	t.throws(splitStringOnData, 'Cannot read property \'trim\' of undefined');
+	t.is(splitStringOnData('abc').length, 1);
+	t.is(splitStringOnData(' abc').length, 1);
+	t.is(splitStringOnData(' a b c ').length, 3);
+	t.is(splitStringOnData(' a    c ').length, 2);
 });
 
 test('parsePid', t => {
@@ -108,19 +80,3 @@ test('parsePid', t => {
 
 	t.true(['1234', '",1234', '   ",1234', '",pid=1234'].every(pid => parsePid(pid) === 1234));
 });
-
-test('findStateIndex', t => {
-	const {findStateIndex} = m.util;
-	t.is(findStateIndex(), null);
-	t.is(findStateIndex(1234), null);
-	t.is(findStateIndex('bad string'), null);
-
-	t.is(findStateIndex('\n anything state anything\n'), 10);
-	t.is(findStateIndex(' anything State anything\n'), 10);
-	t.is(findStateIndex(`
-	    state
-	    `), 5);
-	t.is(findStateIndex('  (State)\n'), 3);
-	t.is(findStateIndex('  (STATE) \n'), 3);
-});
-*/

--- a/test.js
+++ b/test.js
@@ -58,23 +58,11 @@ test('all', async t => {
 });
 
 // PidFromPort.list
-// test('list', async t => {
-// 	const list = await m.list();
-// 	t.true(list instanceof Map);
-// 	console.log({list});
-// 	await t.notThrows(m.all(Array.from(list.keys())));
-// });
-
 test('list', async t => {
 	const list = await m.list();
 	t.true(list instanceof Map);
-	// Console.log({list});
-	// await t.notThrows(m.all(Array.from(list.keys())));
-	await t.notThrows(m
-		.list()
-		.then(list => Array.from(list.keys()))
-		.then(m.all)
-	);
+	console.log({list});
+	await t.notThrows(m.all(Array.from(list.keys())));
 });
 
 // PidFromPort.util

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('list', async t => {
 test('getListFn', async t => {
 	const table = await m.util.getListFn();
 	t.true(typeof table === 'string');
-	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table.trim())); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
+	t.true(/\s*(\D+\n)\s*(^\s*(udp|tcp)\d?.*\n)+/gmi.test(table)); // A dumb matcher for {1,2} Header rows and rows that start with udp or tcp
 });
 
 test('isProtocol', t => {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,9 @@ import {serial as test} from 'ava';
 import getPort from 'get-port';
 import m from '.';
 
+// Const {check, gen} = require('ava-check');
+const {check, gen, property} = require('testcheck');
+
 const pidFromPort = m;
 
 const startNewServer = port => {
@@ -80,3 +83,28 @@ test('parsePid', t => {
 
 	t.true(['1234', '",1234', '   ",1234', '",pid=1234'].every(pid => parsePid(pid) === 1234));
 });
+
+const {toLowerCase} = m.util;
+test('toLowerCase', t => {
+	t.true(
+		check(
+			property(gen.string, str => toLowerCase(str) === str.toLowerCase()),
+			{numTests: 100}
+		)
+	);
+});
+
+const {stringToTable} = m.util;
+test('stringToTable', t => {
+	t.true(
+		check(
+			property(gen.string, str => {
+				const res = stringToTable(str);
+				return typeof res.headers === 'string' && Array.isArray(res.rows) && res.headers + '\n' + res.rows.join('\n') === str;
+			},
+			{numTests: 100}
+			)
+		)
+	);
+});
+

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@
 // Import http from 'http';
 import {serial as test} from 'ava';
 // Import getPort from 'get-port';
-import execa from 'execa';
 import m from '.';
 // Const pidFromPort = m;
 //
@@ -26,16 +25,11 @@ import m from '.';
 
 // PidFromPort.list
 test('list', async t => {
-	const names = await execa.stdout('lsof');
-	console.log({names});
 	const list = await m.list();
 	t.true(list instanceof Map);
 	const altList = await m.list();
 	console.log({list});
 	console.log({altList});
-
-	const names2 = await execa.stdout('lsof');
-	console.log({names2});
 	await t.notThrows(m.all(Array.from(list.keys())));
 });
 


### PR DESCRIPTION
This pull request provides a solution for issue #3 where an empty `(state)` column in the `netstat` table would produce a shorter than expected array and therefore the incorrect pid. 
+ Merged the Mac and Linux commands to both use `lsof -Pn -i` along with a few other things to organize some of the code.
+ Added Appveyor to test on windows
+ Added docstrings to all of the functions